### PR TITLE
Add ShopMy affiliate click tracking script

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -164,5 +164,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   })();
 </script>
   <script src="{{ 'tiny-img-link-preloader.js' | asset_url }}" defer></script>
+
+  {%- comment -%} ShopMy affiliate click tracking (client-requested). {%- endcomment -%}
+  <script async src="https://static.shopmy.us/Affiliates/sms_aff_clicktrack.js?domain=freestyle.world&expires=30"></script>
 </body>
 </html>


### PR DESCRIPTION
Client-requested: add the ShopMy affiliate click-tracking script to the storefront.

## Change

One line added to `layout/theme.liquid`, immediately before the closing `</body>` tag:

```html
<script async src="https://static.shopmy.us/Affiliates/sms_aff_clicktrack.js?domain=freestyle.world&expires=30"></script>
```

Tag is used exactly as ShopMy supplied it — `async`, so it stays off the critical rendering path.

## Notes

- Added to `layout/theme.liquid`, which is the layout Shopify actually renders. There is a stray root-level `theme.liquid` in the repo that also has a `</body>`; it is not used by the storefront, so it was intentionally left alone.
- This is a third-party script on an external origin (`static.shopmy.us`). It is `async`, so it should not affect LCP, but worth a look in the Network tab after deploy to confirm it is not contending with the hero image fetch.
- No other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)