### PR TITLE
Add Pill Companion setting to the product variant pill

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -915,10 +915,18 @@
   
                     const countDiv = document.createElement("div");
 
+                    {%- comment -%}
+                      `pill_companion` is a per-template section setting, so a bundle PDP can
+                      append a fixed second-product count (e.g. ' + 216 wipes') while the
+                      diaper count keeps tracking the selected size. Empty string wherever it
+                      is not set, so this is a no-op on every other product template.
+                      NOTE: this block appears twice in updateActiveVariant and the later copy
+                      wins, so both must stay in sync.
+                    {%- endcomment -%}
                     {% if product.handle == 'skinshield-trial-pack' %}
-                      countDiv.textContent = '8 diapers';
+                      countDiv.textContent = '8 diapers' + {{ section.settings.pill_companion | default: '' | json }};
                     {% else %}
-                      countDiv.textContent = count;
+                      countDiv.textContent = count + {{ section.settings.pill_companion | default: '' | json }};
                     {% endif %}
 
                     countDiv.classList.add("count-main");
@@ -1027,10 +1035,18 @@
 
                     const countDiv = document.createElement("div");
 
+                    {%- comment -%}
+                      `pill_companion` is a per-template section setting, so a bundle PDP can
+                      append a fixed second-product count (e.g. ' + 216 wipes') while the
+                      diaper count keeps tracking the selected size. Empty string wherever it
+                      is not set, so this is a no-op on every other product template.
+                      NOTE: this block appears twice in updateActiveVariant and the later copy
+                      wins, so both must stay in sync.
+                    {%- endcomment -%}
                     {% if product.handle == 'skinshield-trial-pack' %}
-                      countDiv.textContent = '8 diapers';
+                      countDiv.textContent = '8 diapers' + {{ section.settings.pill_companion | default: '' | json }};
                     {% else %}
-                      countDiv.textContent = count;
+                      countDiv.textContent = count + {{ section.settings.pill_companion | default: '' | json }};
                     {% endif %}
 
                     countDiv.classList.add("count-main");
@@ -1587,6 +1603,12 @@
       "id": "sizes_accent_colors",
       "label": "Sizes Accent Colors",
       "info": "size - accent_color_top|accent_color_bottom"
+    },
+    {
+      "type": "text",
+      "id": "pill_companion",
+      "label": "Pill Companion",
+      "info": "Appended to the item count in the variant pill, for bundles that include a fixed quantity of a second product. E.g. ' + 216 wipes' makes the pill read '198 diapers + 216 wipes • 1 month supply'. The diaper count still changes with the selected size. Leave blank on non-bundle products."
     },
     {
       "type": "richtext",


### PR DESCRIPTION
Client request (Sam): on the upcoming diapers + wipes bundle PDP, the variant pill should read **"198 diapers + 216 wipes • 1 month supply"** instead of "198 diapers • 1 month supply". The diaper count keeps adapting to the selected size; the wipes figure is fixed.

## Approach

Rather than gating on a product handle or template suffix in the theme, this adds a **"Pill Companion"** text setting to the `Main Product` section.

Section settings are stored **per product template** (under `sections.main.settings` in each `templates/product.*.json`), so filling the field in on one template *is* the scoping. Nothing product-specific is hardcoded, and the client can set and edit it themselves in the theme editor without another code change.

Set it to ` + 216 wipes` on the bundle template → pill reads `198 diapers + 216 wipes • 1 month supply`. Left blank everywhere else → renders `count + ""`, a no-op.

## Notes

- Applied to **both** copies of the pill-building block in `updateActiveVariant` (~line 918 and ~1030). The logic is duplicated in that method and the later copy wins, so changing only one produces inconsistent behaviour. Added a comment at both sites.
- Value goes through `| default: '' | json`. The `default` is load-bearing — without it an unset setting renders `null` and the pill would read "198 diapersnull". `json` handles quote/escape safety.
- The count itself is regex-parsed from the variant title (`Size 4 (22-37lbs) - 198 diapers`), which is why it adapts per size for free.
- Deliberately **not** changed: `countDiv` at ~line 1240 builds `.count-div` for the size-picker labels, not the pill (`.count-main`). `sections/main-product-options.liquid` has the same duplicated pill logic, but no bundle template uses that section.
- The separator the client sees as " - " is actually a CSS dot (`.month-supply::before`), not a character.

## To finish the request

The setting only appears in the theme editor once this is deployed. After merge + deploy, set **Pill Companion** to ` + 216 wipes` (note the leading space) on the bundle product's template. I did not pre-populate `templates/product.skin-protection-duo.json` — those files are auto-generated by the Shopify theme editor, so the value is better owned there than in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)